### PR TITLE
Engine provisioning, deployment and remote HTTP server control available

### DIFF
--- a/marvin_python_toolbox/management/engine.py
+++ b/marvin_python_toolbox/management/engine.py
@@ -39,6 +39,8 @@ logger = get_logger('management.engine')
 MARVIN_HOME = os.getenv('MARVIN_HOME')
 MARVIN_DATA_PATH = os.getenv('MARVIN_DATA_PATH')
 
+VERSION = "0.0.1"
+
 
 @click.group('engine')
 def cli():
@@ -574,3 +576,58 @@ def engine_httpserver(ctx, action, params_file, initial_dataset, dataset,
         httpserver.terminate() if httpserver else None
         logger.info("Http and grpc servers terminated!")
         sys.exit(0)
+
+
+@cli.command('engine-deploy', help='Engine provisioning and deployment command')
+@click.option('--provision', is_flag=True, default=False, help='Forces provisioning')
+@click.option('--package', is_flag=True, default=False, help='Creates engine package')
+@click.option('--skip-clean', is_flag=True, default=False, help='Skips make clean')
+def engine_deploy(provision, package, skip_clean):
+    if provision:
+        subprocess.Popen([
+            "fab",
+            "provision",
+        ], env=os.environ).wait()
+        subprocess.Popen([
+            "fab",
+            "deploy:version={version}".format(version=VERSION),
+        ], env=os.environ).wait()
+    elif package:
+        subprocess.Popen([
+            "fab",
+            "package:version={version}".format(version=VERSION),
+        ], env=os.environ).wait()
+    elif skip_clean:
+        subprocess.Popen([
+            "fab",
+            "deploy:version={version},skip_clean=True".format(version=VERSION),
+        ], env=os.environ).wait()
+    else:
+        subprocess.Popen([
+            "fab",
+            "deploy:version={version}".format(version=VERSION),
+        ], env=os.environ).wait()
+
+
+@cli.command('engine-httpserver-remote', help='Remote HTTP server control command')
+@click.option('--http_host', '-h', default='0.0.0.0', help='Engine executor http bind host')
+@click.option('--http_port', '-p', default=8000, help='Engine executor http port')
+@click.argument('command', type=click.Choice(['start', 'stop', 'status']))
+def engine_httpserver_remote(command, http_host, http_port):
+    if command == "start":
+        subprocess.Popen([
+            "fab",
+            "engine_start:{host},{port}".format(host=http_host, port=http_port)
+        ], env=os.environ).wait()
+    elif command == "stop":
+        subprocess.Popen([
+            "fab",
+            "engine_stop",
+        ], env=os.environ).wait()
+    elif command == "status":
+        subprocess.Popen([
+            "fab",
+            "engine_status",
+        ], env=os.environ).wait()
+    else:
+        print("Usage: marvin engine-httpserver-remote [ start | stop | status ]")

--- a/marvin_python_toolbox/management/templates/python-engine/README.md
+++ b/marvin_python_toolbox/management/templates/python-engine/README.md
@@ -15,8 +15,58 @@ _REPLACE: Add here the list of requirements. For example:_
 
 ## Installation
 
-_REPLACE: Add here the best way to install this engine
+Use the Marvin toolbox to provision, deploy and start the remote HTTP server.
 
+First, edit the `marvin.ini` file, setting the options within the
+`ssh_deployment` section:
+
+1. `host`: the host IP address or name where the engine should be deployed. You
+can enable multi-host deployment using `,` to separate hosts
+2. `port`: the SSH connection port
+3. `user`: the SSH connection username. Currently, only a single user is
+supported. This user should be capable of *passwordless sudo*, although it can
+use password for the SSH connection
+
+Next, ensure that the remotes servers are provisioned (all required software
+are installed):
+
+    marvin engine-deploy --provision
+
+Next, package your engine:
+
+    marvin engine-deploy --package
+
+This will create a compressed archive containing your engine code under the
+`.packages` directory.
+
+Next, deploy your engine to remotes servers:
+
+    marvin engine-deploy
+
+By default, a dependency clean will be executed at each deploy. You can skip it
+using:
+
+    marvin engine-deploy --skip-clean
+
+Next, you can start the HTTP server in the remotes servers:
+
+    marvin engine-httpserver-remote start
+
+You can check if the HTTP server is running:
+
+    marvin engine-httpserver-remote status
+
+And stop it:
+
+    marvin engine-httpserver-remote stop
+
+After starting, you can test it by making a HTTP request to any endpoint, like:
+
+    curl -v http://example.com/predictor/health
+
+Under the hood, this engine uses Fabric to define provisioning and deployment
+process. Check the `fabfile.py` for more information. You can add new tasks or
+edit existing ones to match your provisioning and deployment pipeline.
 
 ## Development
 

--- a/marvin_python_toolbox/management/templates/python-engine/fabfile.py
+++ b/marvin_python_toolbox/management/templates/python-engine/fabfile.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
 
-"""
-Fabric file.
-
-This file defines provisioning and deployment tasks for a Marvin engine.
-"""
 
 from fabric.api import env
 from fabric.api import run
@@ -18,10 +13,12 @@ from fabric.state import output
 from marvin_python_toolbox import __version__ as TOOLBOX_VERSION
 from marvin_python_toolbox.common.config import Config
 
+_host = Config.get("host", section="ssh_deployment").split(",")
 _port = Config.get("port", section="ssh_deployment")
 _user = Config.get("user", section="ssh_deployment")
 
-env.hosts = ["{}@{}:{}".format(_user, h, _port) for h in Config.get("hosts", section="ssh_deployment").split(",")]
+for h in _host:
+    env.hosts.append("{user}@{host}:{port}".format(user=_user, host=h, port=_port))
 
 output["everything"] = False
 output["running"] = True
@@ -31,6 +28,7 @@ env.margin_engine_executor_prefix = "/opt/marvin/engine-executor"
 env.margin_engine_executor_jar = "marvin-engine-executor-assembly-{version}.jar".format(version=TOOLBOX_VERSION)
 env.marvin_engine_executor_path = env.margin_engine_executor_prefix + "/" + env.margin_engine_executor_jar
 
+
 def install_oracle_jdk():
     sudo("add-apt-repository ppa:webupd8team/java -y")
     sudo("apt-get -qq update")
@@ -38,16 +36,19 @@ def install_oracle_jdk():
     run("echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections")
     sudo("apt-get install -y oracle-java8-installer")
 
+
 def install_virtualenvwrapper():
-    sudo("pip install virtualenvwrapper")
+    run("pip install virtualenvwrapper")
     run("echo 'export WORKON_HOME=${HOME}/.virtualenvs' >> ${HOME}/.profile")
     run("echo 'source /usr/local/bin/virtualenvwrapper.sh' >> ${HOME}/.profile")
+
 
 def install_apache_spark():
     run("curl https://d3kbcqa49mib13.cloudfront.net/spark-2.1.1-bin-hadoop2.6.tgz -o /tmp/spark-2.1.1-bin-hadoop2.6.tgz")
     sudo("tar -xf /tmp/spark-2.1.1-bin-hadoop2.6.tgz -C /opt/")
     sudo("ln -s /opt/spark-2.1.1-bin-hadoop2.6 /opt/spark")
     run("echo 'export SPARK_HOME=/opt/spark' >> ${HOME}/.profile")
+
 
 def install_required_packages():
     sudo("apt-get update -y")
@@ -68,10 +69,12 @@ def install_required_packages():
     sudo("apt-get install -y graphviz")
     sudo("pip install --upgrade pip")
 
+
 def install_marvin_engine_executor():
     sudo("mkdir -p {prefix}".format(prefix=env.margin_engine_executor_prefix))
     with cd("{prefix}".format(prefix=env.margin_engine_executor_prefix)):
         sudo("wget https://s3.amazonaws.com/marvin-engine-executor/{jar}".format(jar=env.margin_engine_executor_jar))
+
 
 def create_marvin_engines_prefix():
     sudo("mkdir -p /opt/marvin/engines")
@@ -81,11 +84,13 @@ def create_marvin_engines_prefix():
     sudo("mkdir -p /var/run/marvin/engines")
     sudo("chown {user}:{user} /var/run/marvin/engines".format(user=env.user))
 
+
 def configure_marvin_environment():
     run("echo 'export MARVIN_HOME=${HOME}/marvin' >> ${HOME}/.profile")
     run("echo 'export MARVIN_DATA_PATH=${MARVIN_HOME}/data' >> ${HOME}/.profile")
     run("mkdir -p ${MARVIN_HOME}")
     run("mkdir -p ${MARVIN_DATA_PATH}")
+
 
 def provision():
     execute(install_required_packages)
@@ -96,22 +101,23 @@ def provision():
     execute(create_marvin_engines_prefix)
     execute(configure_marvin_environment)
 
+
 def package(version):
     package = env.package
     local("mkdir -p .packages")
-    local("tar czvf {package}-{version}.tar.gz --exclude='.packages' --exclude='.vagrant' .".format(
-        package=package, version=version))
-    local("mv {package}-{version}.tar.gz .packages".format(
-        package=package, version=version))
+    local("tar czvf .packages/{package}-{version}.tar.gz --exclude='.packages' .".format(
+          package=package, version=version))
 
-def deploy(version):
+
+def deploy(version, skip_clean=False):
+    execute(engine_stop)
     package = env.package
     put(local_path=".packages/{package}-{version}.tar.gz".format(
         package=package, version=version), remote_path="/tmp/")
     run("mkdir -p /opt/marvin/engines/{package}/{version}".format(
         package=package, version=version))
     with cd("/opt/marvin/engines/{package}/{version}".format(
-        package=package, version=version)):
+            package=package, version=version)):
         run("tar xzvf /tmp/{package}-{version}.tar.gz".format(
             package=package, version=version))
     with cd("/opt/marvin/engines/{package}".format(package=package)):
@@ -122,30 +128,37 @@ def deploy(version):
     with cd("/opt/marvin/engines/{package}/current".format(package=package)):
         run("mkvirtualenv {package}_env".format(package=package))
         run("setvirtualenvproject")
-        run("workon {package}_env && make marvin".format(
-            package=package))
+        if skip_clean:
+            run("workon {package}_env && make marvin".format(
+                package=package))
+        else:
+            run("workon {package}_env && make clean && make marvin".format(
+                package=package))
+    execute(engine_start)
 
-def engine_start(host, port):
+
+def engine_start(http_host, http_port):
     package = env.package
 
     command = (
         "workon {package}_env &&"
         " (marvin engine-httpserver"
-        " -h {host}"
-        " -p {port}"
+        " -h {http_host}"
+        " -p {http_port}"
         " -e {executor}"
         " 1> /var/log/marvin/engines/{package}.out"
         " 2> /var/log/marvin/engines/{package}.err"
         " & echo $! > /var/run/marvin/engines/{package}.pid)"
     ).format(
         package=package,
-        host=host,
-        port=port,
+        http_host=http_host,
+        http_port=http_port,
         executor=env.marvin_engine_executor_path
     )
 
     with cd("/opt/marvin/engines/{package}/current".format(package=package)):
         run(command, pty=False)
+
 
 def engine_stop():
     package = env.package
@@ -156,6 +169,7 @@ def engine_stop():
         run("kill $(cat /var/run/marvin/engines/{package}.pid) {children_pids}".format(
             package=package, children_pids=children_pids))
     run("rm /var/run/marvin/engines/{package}.pid".format(package=package))
+
 
 def engine_status():
     package = env.package

--- a/marvin_python_toolbox/management/templates/python-engine/fabfile.py
+++ b/marvin_python_toolbox/management/templates/python-engine/fabfile.py
@@ -163,12 +163,15 @@ def engine_start(http_host, http_port):
 def engine_stop():
     package = env.package
 
-    with cd("/opt/marvin/engines/{package}/current".format(package=package)):
-        children_pids = run("ps --ppid $(cat /var/run/marvin/engines/{package}.pid) -o pid --no-headers |xargs echo".format(
-            package=package))
-        run("kill $(cat /var/run/marvin/engines/{package}.pid) {children_pids}".format(
-            package=package, children_pids=children_pids))
-    run("rm /var/run/marvin/engines/{package}.pid".format(package=package))
+    pid_file_exists = run("cat /var/run/marvin/engines/{package}.pid".format(
+        package=package), quiet=True)
+    if pid_file_exists.succeeded:
+        with cd("/opt/marvin/engines/{package}/current".format(package=package)):
+            children_pids = run("ps --ppid $(cat /var/run/marvin/engines/{package}.pid) -o pid --no-headers |xargs echo".format(
+                package=package))
+            run("kill $(cat /var/run/marvin/engines/{package}.pid) {children_pids}".format(
+                package=package, children_pids=children_pids))
+            run("rm /var/run/marvin/engines/{package}.pid".format(package=package))
 
 
 def engine_status():

--- a/marvin_python_toolbox/management/templates/python-engine/marvin.ini
+++ b/marvin_python_toolbox/management/templates/python-engine/marvin.ini
@@ -3,6 +3,8 @@ package = {{project.package}}
 type = {{project.type}}
 
 [ssh_deployment]
-hosts = example.com
+# You can enable multi-host deployment like this
+# host = host1.com,host2.com,hostN.com
+host = host1.com
 port = 22
 user = marvin


### PR DESCRIPTION
Hi.

In this PR, we can use the toolbox to provision, deploy and control remote HTTP server status, like starting and stopping.

Provision means to install required software on a remote server.

Deploy means to copy the engine package to remote servers.

Remote HTTP server control means to start, stop and get the status.

I used Fabric as the task automation and orchestration library, just putting it under specific toolbox commands. The engine developer might edit the `fabfile.py` to create custom logic.

The main use scenario is:

1. Create a fresh Ubuntu 16 server somewhere (AWS for example)
2. Create a deployment user (we suggest `marvin`) with passwordless sudo. This user might use password for SSH connection. SSH keys works as well

3. Execute `marvin engine-deploy --provision`
4. Execute `marvin engine-deploy --package`. This will create a deployable package within `.packages` local directory
5. Execute `marvin engine-deploy`. This will stop, deploy (remote copy) the engine package to a specific prefix like `/opt/marvin/engines/example-engine/current` where `current` is a symlink to the current version - the developer might keep several versions deployed, but only one running

The user might also control the remote HTTP server (or servers for multi-host deployment) using `marvin engine-httpserver-remote [ start | stop | status ]`.

I tested it within a `marvin-vagrant-dev` box using an AWS instance.

Additional notes:

1. I used `subprocess.Popen` to execute commands. As the user might type the password, I had to use `wait()`
2. I tried to keep all commands idempotent
3. I tested with Ubuntu 16 64 bits only

:)