### PR TITLE
Bug/model protocol missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ tests/__pycache__
 build
 .idea
 python-toolbox
+.profiling

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl graphviz  ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install libsasl2-dev python-pip graphviz -y ; fi
   - sudo pip install --upgrade pip
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo pip install virtualenvwrapper ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo pip install virtualenvwrapper --ignore-installed six  ; fi
+  - sudo pip install virtualenvwrapper --ignore-installed six
   - source virtualenvwrapper.sh
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkvirtualenv marvin-env         ; fi
 

--- a/marvin_python_toolbox/management/engine.py
+++ b/marvin_python_toolbox/management/engine.py
@@ -44,6 +44,8 @@ MARVIN_DATA_PATH = os.getenv('MARVIN_DATA_PATH')
 
 TOOLBOX_VERSION = "0.0.1"
 
+TESTING = False
+
 
 @click.group('engine')
 def cli():
@@ -555,26 +557,6 @@ def _call_git_init(dest):
         print('WARNING: Could not initialize repository!')
 
 
-@cli.command('engine-httpserver', help='Marvin http api server starts')
-@click.option(
-    '--action',
-    '-a',
-    default='all',
-    type=click.Choice(['all', 'acquisitor', 'tpreparator', 'trainer', 'evaluator', 'ppreparator', 'predictor', 'feedback']),
-    help='Marvin engine action name')
-@click.option('--initial-dataset', '-id', help='Initial dataset file path', type=click.Path(exists=True))
-@click.option('--dataset', '-d', help='Dataset file path', type=click.Path(exists=True))
-@click.option('--model', '-m', help='Engine model file path', type=click.Path(exists=True))
-@click.option('--metrics', '-me', help='Engine Metrics file path', type=click.Path(exists=True))
-@click.option('--model-protocol', '-mp', default='', help='Marvin model protocol to be loaded during initialization.')
-@click.option('--params-file', '-pf', default='engine.params', help='Marvin engine params file path', type=click.Path(exists=True))
-@click.option('--spark-conf', '-c', default='/opt/spark/conf', type=click.Path(exists=True), help='Spark configuration folder path to be used in this session')
-@click.option('--http-host', '-h', default='localhost', help='Engine executor http bind host')
-@click.option('--http-port', '-p', default=8000, help='Engine executor http port')
-@click.option('--executor-path', '-e', help='Marvin engine executor jar path', type=click.Path(exists=True))
-@click.option('--max-workers', '-w', default=multiprocessing.cpu_count(), help='Max number of grpc threads workers per action')
-@click.option('--max-rpc-workers', '-rw', default=multiprocessing.cpu_count(), help='Max number of grpc workers per action')
-@click.pass_context
 def engine_httpserver(ctx, action, params_file, initial_dataset, dataset,
                       model, metrics, model_protocol, spark_conf, http_host, http_port,
                       executor_path, max_workers, max_rpc_workers):
@@ -613,7 +595,7 @@ def engine_httpserver(ctx, action, params_file, initial_dataset, dataset,
         sys.exit(1)
 
     try:
-        while True:
+        while True and not TESTING:
             time.sleep(100)
     except KeyboardInterrupt:
         logger.info("Terminating http and grpc servers...")
@@ -621,6 +603,35 @@ def engine_httpserver(ctx, action, params_file, initial_dataset, dataset,
         httpserver.terminate() if httpserver else None
         logger.info("Http and grpc servers terminated!")
         sys.exit(0)
+
+
+@cli.command('engine-httpserver', help='Marvin http api server starts')
+@click.option(
+    '--action',
+    '-a',
+    default='all',
+    type=click.Choice(['all', 'acquisitor', 'tpreparator', 'trainer', 'evaluator', 'ppreparator', 'predictor', 'feedback']),
+    help='Marvin engine action name')
+@click.option('--initial-dataset', '-id', help='Initial dataset file path', type=click.Path(exists=True))
+@click.option('--dataset', '-d', help='Dataset file path', type=click.Path(exists=True))
+@click.option('--model', '-m', help='Engine model file path', type=click.Path(exists=True))
+@click.option('--metrics', '-me', help='Engine Metrics file path', type=click.Path(exists=True))
+@click.option('--model-protocol', '-mp', default='', help='Marvin model protocol to be loaded during initialization.')
+@click.option('--params-file', '-pf', default='engine.params', help='Marvin engine params file path', type=click.Path(exists=True))
+@click.option('--spark-conf', '-c', default='/opt/spark/conf', type=click.Path(exists=True), help='Spark configuration folder path to be used in this session')
+@click.option('--http-host', '-h', default='localhost', help='Engine executor http bind host')
+@click.option('--http-port', '-p', default=8000, help='Engine executor http port')
+@click.option('--executor-path', '-e', help='Marvin engine executor jar path', type=click.Path(exists=True))
+@click.option('--max-workers', '-w', default=multiprocessing.cpu_count(), help='Max number of grpc threads workers per action')
+@click.option('--max-rpc-workers', '-rw', default=multiprocessing.cpu_count(), help='Max number of grpc workers per action')
+@click.pass_context
+def engine_httpserver_cli(ctx, action, params_file, initial_dataset, dataset,
+                      model, metrics, model_protocol, spark_conf, http_host, http_port,
+                      executor_path, max_workers, max_rpc_workers):
+    engine_httpserver(ctx, action, params_file, initial_dataset, dataset,
+        model, metrics, model_protocol, spark_conf, http_host, http_port,
+        executor_path, max_workers, max_rpc_workers)
+
 
 def generate_rpc_args_params_string(**kwargs):
     params = []

--- a/marvin_python_toolbox/management/notebook.py
+++ b/marvin_python_toolbox/management/notebook.py
@@ -30,7 +30,7 @@ def cli():
 @cli.command('notebook', help='Start the Jupyter notebook server.')
 @click.option('--port', '-p', default=8888, help='Jupyter server port')
 @click.option('--enable-security', is_flag=True, help='Enable jupyter notebook token security.')
-@click.option('--spark-conf', '-c', default='/opt/spark/conf', type=click.Path(exists=True), help='Spark configuration folder path to be used in this session')
+@click.option('--spark-conf', '-c', envvar='SPARK_HOME', type=click.Path(exists=True), help='Spark configuration folder path to be used in this session')
 @click.pass_context
 def notebook_cli(ctx, port, enable_security, spark_conf):
     notebook(ctx, port, enable_security, spark_conf)

--- a/tests/management/test_engine.py
+++ b/tests/management/test_engine.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# from click.testing import CliRunner
-
 try:
     import mock
 except ImportError:
@@ -30,10 +28,12 @@ from marvin_python_toolbox.management.engine import engine_httpserver
 
 
 class mocked_ctx(object):
-    obj = {'package_name': 'test_package',
-           'config': {
-                'inidir': 'test_dir'
-           }}
+    obj = {'package_name': 'test_package', 'config': {'inidir': 'test_dir'}}
+
+
+def mocked_sleep(value):
+    if value == 100:
+        raise KeyboardInterrupt()
 
 
 class mocked_acquisitor():
@@ -58,17 +58,20 @@ def test_dryrun(system_mocked, exit_mocked, MarvinDryRun_mocked, time_mocked):
     spark_conf = '/opt/spark/conf'
     time_mocked.return_value = 555
 
-    dryrun(ctx=mocked_ctx, action=action, params_file=params, messages_file=messages_file, feedback_file=feedback_file, initial_dataset=None, dataset=None, model=None, metrics=None, response=False, spark_conf=spark_conf, profiling=None)
+    dryrun(ctx=mocked_ctx, action=action, params_file=params, messages_file=messages_file, feedback_file=feedback_file, initial_dataset=None,
+           dataset=None, model=None, metrics=None, response=False, spark_conf=spark_conf, profiling=None)
 
     time_mocked.assert_called()
     exit_mocked.assert_called_with("Stoping process!")
     MarvinDryRun_mocked.assert_called_with(ctx=mocked_ctx, messages=[{}, {}], print_response=False)
 
-    MarvinDryRun_mocked.return_value.execute.assert_called_with(clazz='Feedback', dataset=None, initial_dataset=None, metrics=None, model=None, params={}, profiling_enabled=None)
+    MarvinDryRun_mocked.return_value.execute.assert_called_with(clazz='Feedback', dataset=None, initial_dataset=None, metrics=None, model=None,
+                                                                params={}, profiling_enabled=None)
 
     action = 'acquisitor'
 
-    dryrun(ctx=mocked_ctx, action=action, params_file=params, messages_file=messages_file, feedback_file=feedback_file, initial_dataset=None, dataset=None, model=None, metrics=None, response=False, spark_conf=spark_conf, profiling=None)
+    dryrun(ctx=mocked_ctx, action=action, params_file=params, messages_file=messages_file, feedback_file=feedback_file, initial_dataset=None,
+           dataset=None, model=None, metrics=None, response=False, spark_conf=spark_conf, profiling=None)
 
     time_mocked.assert_called()
     MarvinDryRun_mocked.assert_called_with(ctx=mocked_ctx, messages=[{}, {}], print_response=False)
@@ -114,21 +117,32 @@ def test_marvindryrun(import_mocked, dumps_mocked):
     dumps_mocked.assert_called_with(None, indent=4, sort_keys=True)
 
 
-@mock.patch('marvin_python_toolbox.management.engine.TESTING')
+@mock.patch('marvin_python_toolbox.management.engine.sys.exit')
+@mock.patch('marvin_python_toolbox.management.engine.time.sleep')
 @mock.patch('marvin_python_toolbox.management.engine.MarvinData')
 @mock.patch('marvin_python_toolbox.management.engine.Config')
 @mock.patch('marvin_python_toolbox.management.engine.subprocess.Popen')
-def test_engine_httpserver(Popen_mocked, Config_mocked, MarvinData_mocked, TESTING_mocked):
-    TESTING_mocked.return_value = True
-    engine_httpserver(ctx=mocked_ctx, action='all', params_file='test_params', initial_dataset='test_id',
-        dataset='test_d', model='test_m', metrics='test_me', model_protocol='test_protocol',
-        spark_conf='test_conf', http_host='test_host', http_port=9999, executor_path='test_executor',
-        max_workers=9, max_rpc_workers=99)
+def test_engine_httpserver(Popen_mocked, Config_mocked, MarvinData_mocked, sleep_mocked, exit_mocked):
+
+    sleep_mocked.side_effect = mocked_sleep
+
+    engine_httpserver(ctx=mocked_ctx, action='all', params_file='test_params', initial_dataset='test_id', dataset='test_d', model='test_m', metrics='test_me',
+                      model_protocol='test_protocol', spark_conf='test_conf', http_host='test_host', http_port=9999, executor_path='test_executor',
+                      max_workers=9, max_rpc_workers=99)
 
     expected_calls = []
-    expected_calls.append(call(['marvin', 'engine-grpcserver', '-a', 'all', '-w', '9','-rw', '99',
-        '-me', 'test_me', '-pf', 'test_params', '-m', 'test_m', '-id', 'test_id',
-        '-d', 'test_d']))
+
+    expected_calls.append(call([
+        'marvin', 'engine-grpcserver',
+        '-a', 'all',
+        '-w', '9',
+        '-rw', '99',
+        '-me', 'test_me',
+        '-pf', 'test_params',
+        '-m', 'test_m',
+        '-id', 'test_id',
+        '-d', 'test_d']
+    ))
 
     expected_calls.append(call([
         'java',
@@ -137,6 +151,8 @@ def test_engine_httpserver(Popen_mocked, Config_mocked, MarvinData_mocked, TESTI
         '-DmarvinConfig.port=9999',
         '-DmarvinConfig.modelProtocol=test_protocol',
         '-jar',
-        MarvinData_mocked.download_file('test_executor')]))
+        MarvinData_mocked.download_file('test_executor')]
+    ))
 
     Popen_mocked.assert_has_calls(expected_calls)
+    exit_mocked.assert_called_once_with(0)

--- a/tests/management/test_engine.py
+++ b/tests/management/test_engine.py
@@ -127,7 +127,7 @@ def test_engine_httpserver(Popen_mocked, Config_mocked, MarvinData_mocked, sleep
     sleep_mocked.side_effect = mocked_sleep
 
     engine_httpserver(ctx=mocked_ctx, action='all', params_file='test_params', initial_dataset='test_id', dataset='test_d', model='test_m', metrics='test_me',
-                      model_protocol='test_protocol', spark_conf='test_conf', http_host='test_host', http_port=9999, executor_path='test_executor',
+                      protocol='test_protocol', spark_conf='test_conf', http_host='test_host', http_port=9999, executor_path='test_executor',
                       max_workers=9, max_rpc_workers=99)
 
     expected_calls = []


### PR DESCRIPTION
This PR adds code to fix an issue with engine-httpserver CLI command. This command was suppressing important arguments to the engine-grpcserver and to engine-executor.

To validate the model protocol:
 1 - Clone this branch and make workon on a Marvin engine environment
 2 - Run pip install -e <path to this code>.
 3 - Run marvin engine-httpserver.
 4 - Do a POST request to start a pipeline and save the protocol returned.
 5 - Stop the engine-httpserver and run:
        - marvin engine-httpserver -mp <your_protocol>
 6 - Check that the model with your protocol was loaded.

To validate additional parameters treated:
 1 - Clone this branch and make workon on a Marvin engine environment
 2 - Run pip install -e <path to this code>.
 3 - Run marvin engine-httpserver -id <path to initial dataset> -d <path to dataset> -m <path to model> -me <path to model evaluator> -pf <path to params file>
 4 - Check that the artifacts were generated in the paths specified.