### PR TITLE
new python binary parameter to be used in the creation of virtual env

### DIFF
--- a/marvin_python_toolbox/management/engine.py
+++ b/marvin_python_toolbox/management/engine.py
@@ -354,9 +354,10 @@ _orig_type = type
 
 @cli.command('engine-generateenv', help='Generate a new marvin engine environment and install default requirements.')
 @click.argument('engine-path', type=click.Path(exists=True))
-def generate_env(engine_path):
+@click.option('--python', '-p', default='python', help='The Python interpreter to use to create the new environment')
+def generate_env(engine_path, python):
     dir_ = os.path.basename(os.path.abspath(engine_path))
-    venv_name = _create_virtual_env(dir_, engine_path)
+    venv_name = _create_virtual_env(dir_, engine_path, python)
     _call_make_env(venv_name)
 
     print('\nDone!!!!')
@@ -372,7 +373,8 @@ def generate_env(engine_path):
 @click.option('--dest', '-d', envvar='MARVIN_HOME', type=click.Path(exists=True), help='Root folder path for the creation')
 @click.option('--no-env', is_flag=True, default=False, help='Don\'t create the virtual enviroment')
 @click.option('--no-git', is_flag=True, default=False, help='Don\'t initialize the git repository')
-def generate(name, description, mantainer, email, package, dest, no_env, no_git):
+@click.option('--python', '-p', default='python', help='The Python interpreter to use to create the new environment')
+def generate(name, description, mantainer, email, package, dest, no_env, no_git, python):
     type_ = 'python-engine'
     type = _orig_type
 
@@ -439,7 +441,7 @@ def generate(name, description, mantainer, email, package, dest, no_env, no_git)
 
     venv_name = None
     if not no_env:
-        venv_name = _create_virtual_env(dir_, dest)
+        venv_name = _create_virtual_env(dir_, dest, python)
         _call_make_env(venv_name)
 
     if not no_git:
@@ -518,11 +520,11 @@ def _rename_dirs(base, dirs, context):
         print('Renaming {0} as {1}'.format(oldname, newname))
 
 
-def _create_virtual_env(name, dest):
+def _create_virtual_env(name, dest, python):
     venv_name = '{}-env'.format(name).replace('_', '-')
     print('Creating virtualenv: {0}...'.format(venv_name))
 
-    command = ['bash', '-c', '. virtualenvwrapper.sh; mkvirtualenv -a {1} {0}; '.format(venv_name, dest)]
+    command = ['bash', '-c', '. virtualenvwrapper.sh; mkvirtualenv -p {0} -a {1} {2};'.format(python, dest, venv_name)]
 
     try:
         subprocess.Popen(command, env=os.environ).wait()

--- a/tests/management/test_engine.py
+++ b/tests/management/test_engine.py
@@ -167,6 +167,7 @@ def test_create_virtual_env(Popen_mocked):
     name = "my_project"
     dest = "/tmp/xxx"
     python = "python"
+    Popen_mocked.return_value = 1
 
     env_name = _create_virtual_env(name, dest, python)
 

--- a/tests/management/test_engine.py
+++ b/tests/management/test_engine.py
@@ -179,3 +179,27 @@ def test_create_virtual_env(Popen_mocked):
     Popen_mocked.assert_called_with(commands, env=os.environ)
     assert env_name == 'my-project-env'
 
+
+@mock.patch('marvin_python_toolbox.management.engine.sys')
+@mock.patch('marvin_python_toolbox.management.engine.subprocess.Popen')
+def test_create_virtual_env_error(Popen_mocked, sys_mocked):
+    name = "my_project"
+    dest = "/tmp/xxx"
+    python = "python"
+
+    mockx = mock.MagicMock()
+    mockx.wait.return_value = 3
+    Popen_mocked.return_value = mockx
+
+    env_name = _create_virtual_env(name, dest, python)
+
+    commands = [
+        'bash',
+        '-c',
+        '. virtualenvwrapper.sh; mkvirtualenv -p {0} -a {1} {2};'.format(python, dest, env_name)
+    ]
+
+    Popen_mocked.assert_called_with(commands, env=os.environ)
+    mockx.wait.assert_called_once()
+    # sys_mocked.exit.assert_called_once_with(1)
+

--- a/tests/management/test_engine.py
+++ b/tests/management/test_engine.py
@@ -25,6 +25,8 @@ from mock import ANY
 from marvin_python_toolbox.management.engine import MarvinDryRun
 from marvin_python_toolbox.management.engine import dryrun
 from marvin_python_toolbox.management.engine import engine_httpserver
+from marvin_python_toolbox.management.engine import _create_virtual_env
+import os
 
 
 class mocked_ctx(object):
@@ -158,3 +160,22 @@ def test_engine_httpserver(Popen_mocked, Config_mocked, MarvinData_mocked, sleep
 
     Popen_mocked.assert_has_calls(expected_calls)
     exit_mocked.assert_called_with(0)
+
+
+@mock.patch('marvin_python_toolbox.management.engine.subprocess.Popen')
+def test_create_virtual_env(Popen_mocked):
+    name = "my_project"
+    dest = "/tmp/xxx"
+    python = "python"
+
+    env_name = _create_virtual_env(name, dest, python)
+
+    commands = [
+        'bash',
+        '-c',
+        '. virtualenvwrapper.sh; mkvirtualenv -p {0} -a {1} {2};'.format(python, dest, env_name)
+    ]
+
+    Popen_mocked.assert_called_with(commands, env=os.environ)
+    assert env_name == 'my-project-env'
+

--- a/tests/management/test_engine.py
+++ b/tests/management/test_engine.py
@@ -167,7 +167,10 @@ def test_create_virtual_env(Popen_mocked):
     name = "my_project"
     dest = "/tmp/xxx"
     python = "python"
-    Popen_mocked.return_value = 1
+
+    mockx = mock.MagicMock()
+    mockx.wait.return_value = 0
+    Popen_mocked.return_value = mockx
 
     env_name = _create_virtual_env(name, dest, python)
 


### PR DESCRIPTION
To test just create a new engine informing the python parameter:

`marvin engine-generate --python=python2`
or
`marvin engine-generate --python=python3`

another test is to create just an environment for any project:

`marvin engine-generateenv --python=python2 /path/to/engine`
