### PR TITLE
Improving test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ before_install:
   - export MARVIN_HOME=./marvin_home
   - export MARVIN_DATA_PATH=./marvin_data
   - export SPARK_HOME=./spark-2.1.1-bin-hadoop2.6
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py          ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo python get-pip.py                   ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo easy_install pip          ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                    ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl graphviz  ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install libsasl2-dev python-pip graphviz -y ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkvirtualenv marvin-env         ; fi
 
 install:
-  - make marvin
   - pip install codecov
+  - make marvin
 
 script:
   - marvin test

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ before_install:
   - export MARVIN_HOME=./marvin_home
   - export MARVIN_DATA_PATH=./marvin_data
   - export SPARK_HOME=./spark-2.1.1-bin-hadoop2.6
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo easy_install pip          ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py          ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo python get-pip.py                   ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                    ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl graphviz  ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install libsasl2-dev python-pip graphviz -y ; fi
@@ -30,7 +31,6 @@ before_install:
 
 install:
   - make marvin
-  - pip install --upgrade pip
   - pip install codecov
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ before_install:
   - export MARVIN_HOME=./marvin_home
   - export MARVIN_DATA_PATH=./marvin_data
   - export SPARK_HOME=./spark-2.1.1-bin-hadoop2.6
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo easy_install pip          ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py          ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo python get-pip.py                   ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                    ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl graphviz  ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install libsasl2-dev python-pip graphviz -y ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_install:
 
 install:
   - make marvin
+  - pip install --upgrade pip
   - pip install codecov
 
 script:

--- a/marvin_python_toolbox/common/config.py
+++ b/marvin_python_toolbox/common/config.py
@@ -39,7 +39,6 @@ logger = get_logger('core')
 
 def load_conf_from_file(path=None, section='marvin'):
     data = {}
-    config_parser = ConfigParser()
     config_path = path  # try to get config path from args
     if not config_path:  # try to get config file from env
         config_path = os.getenv('MARVIN_CONFIG_FILE') or os.getenv('CONFIG_FILE')
@@ -50,7 +49,9 @@ def load_conf_from_file(path=None, section='marvin'):
     try:
         data = config_parser[section]
     except NoSectionError:
-        pass
+        logger.warn('Couldn\'t find "{section}" section in "{path}"'.format(
+            section=section, path=config_path
+        ))
 
     return data
 

--- a/marvin_python_toolbox/management/hive.py
+++ b/marvin_python_toolbox/management/hive.py
@@ -634,7 +634,8 @@ class HiveDataImporter(object):
     def get_table_location(self, conn, table_name):
         cursor = conn.cursor()
         cursor.execute("DESCRIBE FORMATTED {}".format(table_name))
-        location = [key[1].strip() for key in cursor.fetchall() if key[0] and key[0].strip().upper() == 'LOCATION:'][0].replace('hdfs://', 'hftp://')
+        location = [key[1].strip() for key in cursor.fetchall() if key[0] and key[0].strip().upper() == 'LOCATION:']
+        location = location[0].replace('hdfs://', 'hftp://')
         cursor.close()
         return location
 

--- a/marvin_python_toolbox/management/hive.py
+++ b/marvin_python_toolbox/management/hive.py
@@ -40,6 +40,10 @@ def cli():
 
 @cli.command('hive-generateconf', help='Generate default configuration file')
 @click.pass_context
+def hive_generateconf_cli(ctx):
+    hive_generateconf(ctx)
+
+
 def hive_generateconf(ctx):
     default_conf = [{
         "origin_host": "xxx_host_name",
@@ -61,6 +65,10 @@ def hive_generateconf(ctx):
 @click.option('--queue', '-h', default='default')
 @click.option('--engine', default=(os.path.relpath(".", "..")), help='Marvin engine name (default is the current folder)')
 @click.pass_context
+def hive_resetremote_cli(ctx, host, engine, queue):
+    hive_resetremote(ctx, host, engine, queue)
+
+
 def hive_resetremote(ctx, host, engine, queue):
     hdi = HiveDataImporter(
         engine=engine,
@@ -71,6 +79,7 @@ def hive_resetremote(ctx, host, engine, queue):
         sample_sql=None,
         max_query_size=None,
         destination_host=None,
+        destination_port=None,
         destination_host_username='vagrant',
         destination_host_password='vagrant',
         destination_hdfs_root_path='/user/hive/warehouse/',
@@ -97,10 +106,21 @@ def hive_resetremote(ctx, host, engine, queue):
 @click.option('--sql-id', '-q', help='If informed the process will be applied exclusivelly for this sample sql')
 @click.option('--conf', '-c', default='hive_dataimport.conf', help='Hive data import configuration file')
 @click.pass_context
+def hive_dataimport_cli(
+    ctx, conf, sql_id, engine, skip_remote_preparation, force_copy_files, validate, force,
+    force_remote, max_query_size, destination_host, destination_port, destination_host_username,
+    destination_host_password, destination_hdfs_root_path
+):
+    hive_dataimport(
+        ctx, conf, sql_id, engine, skip_remote_preparation, force_copy_files, validate, force,
+        force_remote, max_query_size, destination_host, destination_port, destination_host_username,
+        destination_host_password, destination_hdfs_root_path
+    )
+
 def hive_dataimport(
     ctx, conf, sql_id, engine, skip_remote_preparation, force_copy_files, validate, force,
-    force_remote, max_query_size, destination_host, destination_port, destination_host_username, destination_host_password,
-    destination_hdfs_root_path
+    force_remote, max_query_size, destination_host, destination_port, destination_host_username,
+    destination_host_password, destination_hdfs_root_path
 ):
 
     initial_start_time = time.time()

--- a/marvin_python_toolbox/management/hive.py
+++ b/marvin_python_toolbox/management/hive.py
@@ -469,7 +469,12 @@ class HiveDataImporter():
 
     @property
     def temp_table_name(self):
-        return "{}_{}_{}_{}".format(self.temp_table_prefix, self.origin_db, self.target_table_name, hashlib.sha1(slugify(self.sample_sql)).hexdigest())
+        return "{}_{}_{}_{}".format(
+            self.temp_table_prefix,
+            self.origin_db,
+            self.target_table_name,
+            hashlib.sha1(slugify(self.sample_sql).encode('utf-8')).hexdigest()
+        )
 
     @property
     def full_table_name(self):

--- a/marvin_python_toolbox/management/hive.py
+++ b/marvin_python_toolbox/management/hive.py
@@ -29,6 +29,8 @@ import hashlib
 
 from .._logging import get_logger
 
+from .._compatibility import six
+
 
 logger = get_logger('management.hive')
 
@@ -176,7 +178,7 @@ def read_config(filename):
         return {}
 
 
-class HiveDataImporter(object):
+class HiveDataImporter():
     def __init__(
         self, origin_host, origin_db, origin_queue, target_table_name, sample_sql, engine,
         max_query_size, destination_host, destination_port, destination_host_username, destination_host_password,

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -55,12 +55,18 @@ class TestConfig:
 
         ConfigParserMocked.assert_called_once_with(os.environ['DEFAULT_CONFIG_PATH'])
 
-    @mock.patch('marvin_python_toolbox.common.config.ConfigObj')
-    def test_load_conf_from_default_path_with_invalid_section(self, ConfigParserMocked):
+    @mock.patch('marvin_python_toolbox.common.config.logger')
+    @mock.patch('marvin_python_toolbox.common.config.ConfigObj.__getitem__')
+    def test_load_conf_from_default_path_with_invalid_section(self, ConfigParserGetItemMocked, logger_mocked):
         from configparser import NoSectionError
 
-        ConfigParserMocked.return_value.items.side_effect = NoSectionError('')
-        assert len(load_conf_from_file(section='invalidsection')) == 0
+        filepath = '/path/to/config/file.ini'
+
+        ConfigParserGetItemMocked.side_effect = NoSectionError('')
+        assert len(load_conf_from_file(filepath, section='invalidsection')) == 0
+        logger_mocked.warn.assert_called_once_with(
+            "Couldn't find \"invalidsection\" section in \"/path/to/config/file.ini\""
+        )
 
     @mock.patch('marvin_python_toolbox.common.config.load_conf_from_file')
     def test_get(self, load_conf_from_file_mocked, config_fixture):
@@ -109,4 +115,3 @@ class TestConfig:
         assert Config.get('models.default_context_name', section='section') == 'pdl2'
         assert Config.get('models.default_type_name') == 'pdl'
         assert Config.get('models.default_type_name') == Config.get('models.default_type_name', section='section')
-

--- a/tests/management/test_hive.py
+++ b/tests/management/test_hive.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+# Copyright [2017] [B2W Digital]
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    import mock
+except ImportError:
+    import unittest.mock as mock
+
+from marvin_python_toolbox.management import hive
+
+
+@mock.patch('marvin_python_toolbox.management.hive.json')
+def test_hive_generateconf_write_file_with_json(mocked_json):
+    default_conf = [{
+        "origin_host": "xxx_host_name",
+        "origin_db": "xxx_db_name",
+        "origin_queue": "marvin",
+        "target_table_name": "xxx_table_name",
+        "sample_sql": "SELECT * FROM XXX",
+        "sql_id": "1"
+    }]
+
+    mocked_open = mock.mock_open()
+    with mock.patch('marvin_python_toolbox.management.hive.open', mocked_open, create=True):
+        hive.hive_generateconf(None)
+
+    mocked_open.assert_called_once_with('hive_dataimport.conf', 'w')
+    mocked_json.dump.assert_called_once_with(default_conf, mocked_open(), indent=2)
+
+
+@mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter.reset_remote_tables')
+def test_hive_resetremote_call_HiveDataImporter_reset_remote_tables(reset_mocked): 
+    hive.hive_resetremote(ctx=None, host="test", engine="test", queue="test")
+    reset_mocked.assert_called_once_with()
+
+
+@mock.patch('marvin_python_toolbox.management.hive.read_config')
+@mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter.__init__')
+def test_hive_dataimport_without_config(init_mocked, read_config_mocked):
+    read_config_mocked.return_value = None
+
+    ctx = conf = sql_id = engine = \
+        skip_remote_preparation = force_copy_files = validate = force =\
+        force_remote = max_query_size = destination_host = destination_port =\
+        destination_host_username = destination_host_password = destination_hdfs_root_path = None
+
+    hive.hive_dataimport(
+        ctx, conf, sql_id, engine, 
+        skip_remote_preparation, force_copy_files, validate, force,
+        force_remote, max_query_size, destination_host, destination_port,
+        destination_host_username, destination_host_password, destination_hdfs_root_path
+    )
+
+    init_mocked.assert_not_called()
+
+
+@mock.patch('marvin_python_toolbox.management.hive.read_config')
+@mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter.__init__')
+@mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter.table_exists')
+@mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter.import_sample')
+def test_hive_dataimport_with_config(import_sample_mocked, table_exists_mocked, init_mocked, read_config_mocked):
+    read_config_mocked.return_value = [{'origin_db': 'test', 'target_table_name': 'test'}]
+    init_mocked.return_value = None
+
+    ctx = sql_id = engine = \
+        skip_remote_preparation = force_copy_files = validate =\
+        force_remote = max_query_size = destination_port =\
+        destination_host_username = destination_host_password = destination_hdfs_root_path = None
+
+    force = True
+    conf = '/path/to/conf'
+    destination_host = 'test'
+    # import pdb; pdb.set_trace()
+    hive.hive_dataimport(
+        ctx, conf, sql_id, engine, 
+        skip_remote_preparation, force_copy_files, validate, force,
+        force_remote, max_query_size, destination_host, destination_port,
+        destination_host_username, destination_host_password, destination_hdfs_root_path
+    )
+
+    init_mocked.assert_called_once_with(
+        max_query_size=max_query_size,
+        destination_host=destination_host,
+        destination_port=destination_port,
+        destination_host_username=destination_host_username,
+        destination_host_password=destination_host_password,
+        destination_hdfs_root_path=destination_hdfs_root_path,
+        origin_db='test',
+        target_table_name='test',
+        engine=engine,
+    )
+    import_sample_mocked.assert_called_once_with(
+        create_temp_table=True,
+        copy_files=None,
+        validate_query=None,
+        force_create_remote_table=None
+    )

--- a/tests/management/test_hive.py
+++ b/tests/management/test_hive.py
@@ -250,7 +250,7 @@ class TestHiveDataImporter:
 
     def setup(self):
         self.hdi = hive.HiveDataImporter(
-            max_query_size=None,
+            max_query_size=13,
             destination_host='test',
             destination_port=None,
             destination_host_username=None,
@@ -292,6 +292,7 @@ class TestHiveDataImporter:
     @mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter.retrieve_data_sample')
     def test_validade_query(self, retrieve_mocked, connection_mocked, count_rows_mocked):
         connection_mocked.return_value = 'connection_mocked'
+        retrieve_mocked.return_value = {'estimate_query_mean_per_line': 42}
 
         self.hdi.validade_query()
 
@@ -547,8 +548,6 @@ class TestHiveDataImporter:
         assert data['data_header'][0]['type'] == 'type'
         assert data['total_lines'] == 1
         assert data['data'] == ['test']
-        assert data['estimate_query_size'] == 104
-        assert data['estimate_query_mean_per_line'] == 104
 
     @mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter.show_log')
     def test_count_rows(self, show_log_mocked):

--- a/tests/management/test_hive.py
+++ b/tests/management/test_hive.py
@@ -84,7 +84,7 @@ def test_hive_dataimport_with_config(import_sample_mocked, table_exists_mocked, 
     force = True
     conf = '/path/to/conf'
     destination_host = 'test'
-    # import pdb; pdb.set_trace()
+
     hive.hive_dataimport(
         ctx, conf, sql_id, engine, 
         skip_remote_preparation, force_copy_files, validate, force,
@@ -109,3 +109,204 @@ def test_hive_dataimport_with_config(import_sample_mocked, table_exists_mocked, 
         validate_query=None,
         force_create_remote_table=None
     )
+
+
+@mock.patch('marvin_python_toolbox.management.hive.read_config')
+@mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter.__init__')
+@mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter.table_exists')
+@mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter.import_sample')
+def test_hive_dataimport_with_config_sql_id(import_sample_mocked, table_exists_mocked, init_mocked, read_config_mocked):
+    read_config_mocked.return_value = [
+        {'origin_db': 'test', 'target_table_name': 'test', 'sql_id': 'test'},
+        {'origin_db': 'bla', 'target_table_name': 'bla', 'sql_id': 'bla'},
+    ]
+    init_mocked.return_value = None
+
+    ctx = sql_id = engine = \
+        skip_remote_preparation = force_copy_files = validate =\
+        force_remote = max_query_size = destination_port =\
+        destination_host_username = destination_host_password = destination_hdfs_root_path = None
+
+    sql_id= 'test'
+    force = True
+    conf = '/path/to/conf'
+    destination_host = 'test'
+
+    hive.hive_dataimport(
+        ctx, conf, sql_id, engine, 
+        skip_remote_preparation, force_copy_files, validate, force,
+        force_remote, max_query_size, destination_host, destination_port,
+        destination_host_username, destination_host_password, destination_hdfs_root_path
+    )
+
+    init_mocked.assert_called_once_with(
+        max_query_size=max_query_size,
+        destination_host=destination_host,
+        destination_port=destination_port,
+        destination_host_username=destination_host_username,
+        destination_host_password=destination_host_password,
+        destination_hdfs_root_path=destination_hdfs_root_path,
+        origin_db='test',
+        target_table_name='test',
+        sql_id='test',
+        engine=engine,
+    )
+    import_sample_mocked.assert_called_once_with(
+        create_temp_table=True,
+        copy_files=None,
+        validate_query=None,
+        force_create_remote_table=None
+    )
+
+
+@mock.patch('marvin_python_toolbox.management.hive.read_config')
+@mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter.table_exists')
+@mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter.import_sample')
+def test_hive_dataimport_with_config_force_false(import_sample_mocked, table_exists_mocked, read_config_mocked):
+    table_exists_mocked.return_value = False
+    read_config_mocked.return_value = [{
+        'origin_db': 'test',
+        'target_table_name': 'test',
+        'origin_queue':'test',
+        'origin_host':'test',
+        'sample_sql':'test',
+        'sql_id':'test'
+    }]
+
+    ctx = sql_id = engine = \
+        skip_remote_preparation = force_copy_files = validate =\
+        force_remote = max_query_size = destination_port =\
+        destination_host_username = destination_host_password = destination_hdfs_root_path = None
+
+    force = False
+    conf = '/path/to/conf'
+    destination_host = 'test'
+
+    hdi = hive.HiveDataImporter(
+        max_query_size=max_query_size,
+        destination_host=destination_host,
+        destination_port=destination_port,
+        destination_host_username=destination_host_username,
+        destination_host_password=destination_host_password,
+        destination_hdfs_root_path=destination_hdfs_root_path,
+        origin_db='test',
+        target_table_name='test',
+        engine=engine,
+        sql_id='test',
+        origin_host='test',
+        origin_queue='test',
+        sample_sql='test',
+    )
+
+    with mock.patch.object(hive.HiveDataImporter, '__new__', return_value=hdi) as new_mocked:
+        hive.hive_dataimport(
+            ctx, conf, sql_id, engine, 
+            skip_remote_preparation, force_copy_files, validate, force,
+            force_remote, max_query_size, destination_host, destination_port,
+            destination_host_username, destination_host_password, destination_hdfs_root_path
+        )
+
+        table_exists_mocked.assert_called_once_with(
+            host=hdi.destination_host, db=hdi.origin_db, table=hdi.target_table_name
+        )
+
+        import_sample_mocked.assert_called_once_with(
+            create_temp_table=True,
+            copy_files=None,
+            validate_query=None,
+            force_create_remote_table=None
+        )
+
+
+@mock.patch('marvin_python_toolbox.management.hive.json')
+@mock.patch('marvin_python_toolbox.management.hive.os.path')
+def test_read_config_with_existing_path(path_mocked, json_mocked):
+    path_mocked.exists.return_value = True
+    path_mocked.join.return_value = 'test.conf'
+
+    mocked_open = mock.mock_open()
+    with mock.patch('marvin_python_toolbox.management.hive.open', mocked_open, create=True):
+        hive.read_config("test.conf")
+
+    mocked_open.assert_called_once_with('test.conf', 'r')
+    json_mocked.load.assert_called_once_with(mocked_open())
+
+
+@mock.patch('marvin_python_toolbox.management.hive.json')
+@mock.patch('marvin_python_toolbox.management.hive.os.path')
+def test_read_config_with_not_existing_path(path_mocked, json_mocked):
+    path_mocked.exists.return_value = False
+    path_mocked.join.return_value = 'test.conf'
+
+    mocked_open = mock.mock_open()
+    with mock.patch('marvin_python_toolbox.management.hive.open', mocked_open, create=True):
+        hive.read_config("test.conf")
+
+    mocked_open.assert_not_called()
+    json_mocked.load.assert_not_called()
+
+
+class TestHiveDataImporter:
+
+    def setup_method(self, method):
+        self.hdi = hive.HiveDataImporter(
+            max_query_size=None,
+            destination_host='test',
+            destination_port=None,
+            destination_host_username=None,
+            destination_host_password=None,
+            destination_hdfs_root_path=None,
+            origin_db='test',
+            target_table_name='test',
+            engine=None,
+            sql_id='test',
+            origin_host='test',
+            origin_queue='test',
+            sample_sql='test',
+        )
+
+    @mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter.count_rows')
+    @mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter.get_connection')
+    @mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter.retrieve_data_sample')
+    def test_validade_query(self, retrieve_mocked, connection_mocked, count_rows_mocked):
+        connection_mocked.return_value = 'connection_mocked'
+
+        self.hdi.validade_query()
+
+        connection_mocked.assert_called_once_with(
+            host=self.hdi.origin_host, 
+            db=self.hdi.origin_db, 
+            queue=self.hdi.origin_queue
+        )
+        count_rows_mocked.assert_called_once_with(conn='connection_mocked', sql=self.hdi.sample_sql)
+        retrieve_mocked.assert_called_once_with(conn='connection_mocked', full_table_name=self.hdi.full_table_name)
+
+    @mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter.show_log')
+    @mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter.get_connection')
+    def test_table_exists_table_not_exists(self, connection_mocked, show_log_mocked):
+        cursor = mock.MagicMock()
+        conn = mock.MagicMock()
+        conn.cursor.return_value = cursor
+        cursor.fetchall.return_value = []
+        connection_mocked.return_value = conn
+
+        table_exists = self.hdi.table_exists(host='host', db='db', table='table')
+
+        show_log_mocked.assert_called_once_with(cursor)
+        assert table_exists is False
+
+    @mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter.show_log')
+    @mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter.get_connection')
+    def test_table_exists_table_exists(self, connection_mocked, show_log_mocked):
+        cursor = mock.MagicMock()
+        conn = mock.MagicMock()
+        conn.cursor.return_value = cursor
+        cursor.fetchall.return_value = ['test']
+        connection_mocked.return_value = conn
+
+        table_exists = self.hdi.table_exists(host='host', db='db', table='table')
+
+        show_log_mocked.assert_has_calls([mock.call(cursor)] * 2)
+        assert table_exists is True
+
+

--- a/tests/management/test_hive.py
+++ b/tests/management/test_hive.py
@@ -198,7 +198,7 @@ def test_hive_dataimport_with_config_force_false(import_sample_mocked, table_exi
         sample_sql='test',
     )
 
-    with mock.patch.object(hive.HiveDataImporter, '__new__', return_value=hdi) as new_mocked:
+    with mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter', return_value=hdi):
         hive.hive_dataimport(
             ctx, conf, sql_id, engine, 
             skip_remote_preparation, force_copy_files, validate, force,

--- a/tests/management/test_hive.py
+++ b/tests/management/test_hive.py
@@ -291,6 +291,7 @@ class TestHiveDataImporter:
     @mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter.get_connection')
     @mock.patch('marvin_python_toolbox.management.hive.HiveDataImporter.retrieve_data_sample')
     def test_validade_query(self, retrieve_mocked, connection_mocked, count_rows_mocked):
+        count_rows_mocked.return_value = 1
         connection_mocked.return_value = 'connection_mocked'
         retrieve_mocked.return_value = {'estimate_query_mean_per_line': 42}
 

--- a/tests/management/test_hive.py
+++ b/tests/management/test_hive.py
@@ -248,7 +248,7 @@ def test_read_config_with_not_existing_path(path_mocked, json_mocked):
 
 class TestHiveDataImporter:
 
-    def setup_method(self, method):
+    def setup(self):
         self.hdi = hive.HiveDataImporter(
             max_query_size=None,
             destination_host='test',


### PR DESCRIPTION
```
$ marvin test 
py.test --cov marvin_python_toolbox --cov-report html --cov-report xml --cov-report term-missing tests
================================================================= test session starts ==================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.5.3, pluggy-0.3.1
rootdir: /home/rafaelnovello/marvin/marvin-python-toolbox, inifile: pytest.ini
plugins: testmon-0.9.10, flask-0.10.0, cov-2.5.1
collected 159 items 

tests/test_loader.py .
tests/common/test_config.py ............
tests/common/test_data.py ..........
tests/common/test_data_source_provider.py ...
tests/common/test_http_client.py ..............
tests/common/test_profiling.py ...........
tests/common/test_utils.py .......................
tests/engine_base/test_engine_base_action.py ......................
tests/engine_base/test_engine_base_data_handler.py ..
tests/engine_base/test_engine_base_prediction.py ..
tests/engine_base/test_engine_base_training.py ...
tests/management/test_engine.py .....
tests/management/test_hive.py .......................................
tests/management/test_notebook.py ..
tests/management/test_pkg.py ..........
```