### PR TITLE
Add Jupyter Lab command. Fix #85

### DIFF
--- a/marvin_python_toolbox/management/notebook.py
+++ b/marvin_python_toolbox/management/notebook.py
@@ -52,3 +52,29 @@ def notebook(ctx, port, enable_security, spark_conf):
 
     ret = os.system(' '.join(command))
     sys.exit(ret)
+
+
+@cli.command('lab', help='Start the JupyterLab server.')
+@click.option('--port', '-p', default=8888, help='JupyterLab server port')
+@click.option('--enable-security', is_flag=True, help='Enable jupyterlab token security.')
+@click.option('--spark-conf', '-c', envvar='SPARK_CONF_DIR', type=click.Path(exists=True), help='Spark configuration folder path to be used in this session')
+@click.pass_context
+def lab_cli(ctx, port, enable_security, spark_conf):
+    lab(ctx, port, enable_security, spark_conf)
+
+
+def lab(ctx, port, enable_security, spark_conf):
+    notebookdir = os.path.join(ctx.obj['base_path'], 'notebooks')
+    command = [
+        "SPARK_CONF_DIR={0} YARN_CONF_DIR={0}".format(spark_conf if spark_conf else os.path.join(os.environ["SPARK_HOME"], "conf")),
+        'jupyter-lab',
+        '--notebook-dir', notebookdir,
+        '--ip', '0.0.0.0',
+        '--port', str(port),
+        '--no-browser',
+    ]
+
+    command.append("--NotebookApp.token=") if not enable_security else None
+
+    ret = os.system(' '.join(command))
+    sys.exit(ret)

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ REQUIREMENTS_EXTERNAL = [
     'bumpversion>=0.5.3',
     'click>=3.3',
     'jupyter>=1.0.0',
+    'jupyterlab>=0.32.1',
     'pep8>=1.7.0',
     'virtualenv>=15.0.1',
     'pytest-cov>=1.8.1',

--- a/tests/management/test_notebook.py
+++ b/tests/management/test_notebook.py
@@ -23,7 +23,7 @@ except ImportError:
     import unittest.mock as mock
 
 import os
-from marvin_python_toolbox.management.notebook import notebook
+from marvin_python_toolbox.management.notebook import notebook, lab
 
 
 class mocked_ctx(object):
@@ -56,3 +56,31 @@ def test_notebook_with_security(system_mocked, sys_mocked):
     notebook(ctx, port, enable_security, spark_conf)
 
     system_mocked.assert_called_once_with('SPARK_CONF_DIR=/opt/spark/conf YARN_CONF_DIR=/opt/spark/conf jupyter notebook --notebook-dir /tmp/notebooks --ip 0.0.0.0 --port 8888 --no-browser --config ' + os.environ["MARVIN_ENGINE_PATH"] + '/marvin_python_toolbox/extras/notebook_extensions/jupyter_notebook_config.py')
+
+
+@mock.patch('marvin_python_toolbox.management.notebook.sys')
+@mock.patch('marvin_python_toolbox.management.notebook.os.system')
+def test_jupyter_lab(system_mocked, sys_mocked):
+    ctx = mocked_ctx()
+    port = 8888
+    enable_security = False
+    spark_conf = '/opt/spark/conf'
+    system_mocked.return_value = 1
+
+    lab(ctx, port, enable_security, spark_conf)
+
+    system_mocked.assert_called_once_with('SPARK_CONF_DIR=/opt/spark/conf YARN_CONF_DIR=/opt/spark/conf jupyter-lab --notebook-dir /tmp/notebooks --ip 0.0.0.0 --port 8888 --no-browser --NotebookApp.token=')
+
+
+@mock.patch('marvin_python_toolbox.management.notebook.sys')
+@mock.patch('marvin_python_toolbox.management.notebook.os.system')
+def test_jupyter_lab_with_security(system_mocked, sys_mocked):
+    ctx = mocked_ctx()
+    port = 8888
+    enable_security = True
+    spark_conf = '/opt/spark/conf'
+    system_mocked.return_value = 1
+
+    lab(ctx, port, enable_security, spark_conf)
+
+    system_mocked.assert_called_once_with('SPARK_CONF_DIR=/opt/spark/conf YARN_CONF_DIR=/opt/spark/conf jupyter-lab --notebook-dir /tmp/notebooks --ip 0.0.0.0 --port 8888 --no-browser')


### PR DESCRIPTION
```
marvin test 
py.test --cov marvin_python_toolbox --cov-report html --cov-report xml --cov-report term-missing tests
========================================================= test session starts =========================================================
platform linux2 -- Python 2.7.15rc1, pytest-2.9.2, py-1.5.3, pluggy-0.3.1
rootdir: /home/rafael/marvin/marvin-python-toolbox, inifile: pytest.ini
plugins: testmon-0.9.11, cov-2.5.1
collected 162 items 

tests/test_loader.py .
tests/common/test_config.py ............
tests/common/test_data.py ..........
tests/common/test_data_source_provider.py ...
tests/common/test_http_client.py ..............
tests/common/test_profiling.py ...........
tests/common/test_utils.py .......................
tests/engine_base/test_engine_base_action.py .......................
tests/engine_base/test_engine_base_data_handler.py ..
tests/engine_base/test_engine_base_prediction.py ..
tests/engine_base/test_engine_base_training.py ...
tests/management/test_engine.py .....
tests/management/test_hive.py .......................................
tests/management/test_notebook.py ....
tests/management/test_pkg.py ..........
```