### PR TITLE
ASCII encode error fix for accented words in predict message

### DIFF
--- a/marvin_python_toolbox/engine_base/engine_base_action.py
+++ b/marvin_python_toolbox/engine_base/engine_base_action.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import os
 
 from abc import ABCMeta, abstractmethod

--- a/tests/engine_base/test_engine_base_action.py
+++ b/tests/engine_base/test_engine_base_action.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
 import joblib as serializer
 import pytest
 import os
@@ -111,7 +112,7 @@ class TestEngineBaseAction:
             assert False
 
         except Exception as e:
-            assert str(e) == "(u'MultipleAssignException', '_params')"
+            assert str(e) == "('MultipleAssignException', '_params')"
 
     def test_load_obj_local_persistence(self, engine_action):
         engine_action2 = copy.copy(engine_action)

--- a/tests/engine_base/test_engine_base_action.py
+++ b/tests/engine_base/test_engine_base_action.py
@@ -112,7 +112,8 @@ class TestEngineBaseAction:
             assert False
 
         except Exception as e:
-            assert str(e) == "(u'MultipleAssignException', '_params')"
+            assert str(e.args[0]) == 'MultipleAssignException'
+            assert str(e.args[1]) == '_params'
 
     def test_load_obj_local_persistence(self, engine_action):
         engine_action2 = copy.copy(engine_action)

--- a/tests/engine_base/test_engine_base_action.py
+++ b/tests/engine_base/test_engine_base_action.py
@@ -111,7 +111,7 @@ class TestEngineBaseAction:
             assert False
 
         except Exception as e:
-            assert str(e) == "('MultipleAssignException', '_params')"
+            assert str(e) == "(u'MultipleAssignException', '_params')"
 
     def test_load_obj_local_persistence(self, engine_action):
         engine_action2 = copy.copy(engine_action)

--- a/tests/engine_base/test_engine_base_action.py
+++ b/tests/engine_base/test_engine_base_action.py
@@ -111,7 +111,7 @@ class TestEngineBaseAction:
             assert False
 
         except Exception as e:
-            assert unicode(e) == "('MultipleAssignException', '_params')"
+            assert unicode(e) == "(u'MultipleAssignException', '_params')"
 
     def test_load_obj_local_persistence(self, engine_action):
         engine_action2 = copy.copy(engine_action)

--- a/tests/engine_base/test_engine_base_action.py
+++ b/tests/engine_base/test_engine_base_action.py
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import unicode_literals
 import joblib as serializer
 import pytest
 import os
@@ -112,7 +111,7 @@ class TestEngineBaseAction:
             assert False
 
         except Exception as e:
-            assert str(e) == "('MultipleAssignException', '_params')"
+            assert unicode(e) == "('MultipleAssignException', '_params')"
 
     def test_load_obj_local_persistence(self, engine_action):
         engine_action2 = copy.copy(engine_action)

--- a/tests/engine_base/test_engine_base_action.py
+++ b/tests/engine_base/test_engine_base_action.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from builtins import str
 import joblib as serializer
 import pytest
 import os
@@ -111,7 +112,7 @@ class TestEngineBaseAction:
             assert False
 
         except Exception as e:
-            assert unicode(e) == "(u'MultipleAssignException', '_params')"
+            assert str(e) == "(u'MultipleAssignException', '_params')"
 
     def test_load_obj_local_persistence(self, engine_action):
         engine_action2 = copy.copy(engine_action)


### PR DESCRIPTION
Refering #90 
Closes: #90 