### PR TITLE
Adding a symlink to the data path on engine generate. close #93

### DIFF
--- a/marvin_python_toolbox/management/engine.py
+++ b/marvin_python_toolbox/management/engine.py
@@ -444,6 +444,7 @@ def generate(name, description, mantainer, email, package, dest, no_env, no_git,
 
         _copy_processed_files(TEMPLATE_BASES[type_], dest, context)
         _rename_dirs(dest, RENAME_DIRS, context)
+        _make_data_link(dest)
 
         venv_name = None
         if not no_env:
@@ -567,6 +568,12 @@ def _call_git_init(dest):
         subprocess.Popen(command, env=os.environ).wait()
     except OSError:
         print('WARNING: Could not initialize repository!')
+
+
+def _make_data_link(dest):
+    data_path = os.environ['MARVIN_DATA_PATH']
+    data_link = os.path.join(dest, 'notebooks/data')
+    os.symlink(data_path, data_link)
 
 
 @cli.command('engine-httpserver', help='Marvin http api server starts')

--- a/marvin_python_toolbox/management/templates/python-engine/.gitignore
+++ b/marvin_python_toolbox/management/templates/python-engine/.gitignore
@@ -13,3 +13,4 @@ tests/__pycache__
 .DS_Store
 .packages
 .profiling
+notebooks/data

--- a/tests/management/test_engine.py
+++ b/tests/management/test_engine.py
@@ -26,6 +26,7 @@ from marvin_python_toolbox.management.engine import MarvinDryRun
 from marvin_python_toolbox.management.engine import dryrun
 from marvin_python_toolbox.management.engine import engine_httpserver
 from marvin_python_toolbox.management.engine import _create_virtual_env
+from marvin_python_toolbox.management.engine import _make_data_link
 import os
 
 
@@ -207,3 +208,10 @@ def test_create_virtual_env_error(Popen_mocked, sys_mocked):
     mockx.wait.assert_called_once()
     # sys_mocked.exit.assert_called_once_with(1)
 
+
+@mock.patch('marvin_python_toolbox.management.engine.os.symlink')
+def test_make_data_link_call_symlink(mock_symlink):
+    os.environ['MARVIN_DATA_PATH'] = '/tmp/'
+    dest = '/tmp/'
+    _make_data_link(dest)
+    mock_symlink.assert_called_once_with('/tmp/', '/tmp/notebooks/data')


### PR DESCRIPTION
To test it:
1. Change git branch to nvl_data_link on python toolbox
2. Create a new engine
3. Start the Jupyter Lab or Notebook. You must see the data symlink
4. The notebooks/data folder can't appear on git status