### PR TITLE
Added new Serializer for support keras objects. Closes #86

### DIFF
--- a/marvin_python_toolbox/engine_base/serializers/__init__.py
+++ b/marvin_python_toolbox/engine_base/serializers/__init__.py
@@ -15,9 +15,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .engine_base_action import EngineBaseAction, EngineBaseOnlineAction, EngineBaseBatchAction
-from .engine_base_prediction import EngineBasePrediction
-from .engine_base_data_handler import EngineBaseDataHandler
-from .engine_base_training import EngineBaseTraining
-from .stubs import actions_pb2, actions_pb2_grpc
-from .serializers import KerasSerializer
+from .keras_serializer import KerasSerializer

--- a/marvin_python_toolbox/engine_base/serializers/keras_serializer.py
+++ b/marvin_python_toolbox/engine_base/serializers/keras_serializer.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+# Copyright [2017] [B2W Digital]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from ..._logging import get_logger
+
+logger = get_logger('engine_base_data_handler')
+__all__ = ['KerasSerializer']
+
+
+class KerasSerializer(object):
+    def _serializer_load(self, object_file_path):
+        if object_file_path.split(os.sep)[-1] == 'model':
+            from keras.models import load_model
+
+            logger.debug("Loading model {} using keras serializer.".format(object_file_path))
+            return load_model(object_file_path)
+        else:
+            return super(KerasSerializer, self)._serializer_load(object_file_path)
+
+    def _serializer_dump(self, obj, object_file_path):
+        if object_file_path.split(os.sep)[-1] == 'model':
+            logger.debug("Saving model {} using keras serializer.".format(object_file_path))
+            obj.save(object_file_path)
+        else:
+            super(KerasSerializer, self)._serializer_dump(obj, object_file_path)

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,9 @@ REQUIREMENTS_EXTERNAL = [
     'progressbar2==3.34.3',
     'urllib3==1.21.1',
     'idna==2.5',
+    'Keras==2.2.0',
+    'tensorflow==1.8.0',
+    'bleach==1.5.0',
 ]
 
 # Test dependencies

--- a/tests/engine_base/serializers/test_keras_serializer.py
+++ b/tests/engine_base/serializers/test_keras_serializer.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+# Copyright [2017] [B2W Digital]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+import pytest
+
+from marvin_python_toolbox.engine_base import EngineBaseTraining
+from marvin_python_toolbox.engine_base import KerasSerializer
+
+
+@pytest.fixture
+def engine():
+    class MyEngineAction(KerasSerializer, EngineBaseTraining):
+        def execute(self, **kwargs):
+            pass
+    return MyEngineAction(default_root_path="/tmp/.marvin")
+
+
+class TestKerasSerializer(object):
+    @mock.patch('keras.models.load_model')
+    def test__serializer_load_keras(self, mocked_load, engine):
+        mocked_load.return_value = {"me": "here"}
+        mocked_path = "/tmp/engine/model"
+        obj = engine._serializer_load(object_file_path=mocked_path)
+        mocked_load.assert_called_once_with(mocked_path)
+        assert obj == {"me": "here"}
+
+    @mock.patch('joblib.load')
+    def test__serializer_load_not_keras(self, mocked_load, engine):
+        mocked_path = "/tmp/engine/metrics"
+        mocked_load.return_value = {"me": "here"}
+        obj = engine._serializer_load(object_file_path=mocked_path)
+        mocked_load.assert_called_once_with(mocked_path)
+        assert obj == {"me": "here"}
+
+    def test__serializer_dump_keras(self, engine):
+        mocked_obj = mock.MagicMock()
+        mocked_path = "/tmp/engine/model"
+        engine._serializer_dump(mocked_obj, object_file_path=mocked_path)
+        mocked_obj.save.assert_called_once_with(mocked_path)
+
+    @mock.patch('marvin_python_toolbox.engine_base.EngineBaseTraining._serializer_dump')
+    def test__serializer_dump_not_keras(self, mocked_dump, engine):
+        mocked_obj = mock.MagicMock()
+        mocked_path = "/tmp/engine/metrics"
+        engine._serializer_dump(mocked_obj, object_file_path=mocked_path)
+        mocked_dump.assert_called_once_with(mocked_obj, mocked_path)
+


### PR DESCRIPTION
To test this new feature just create a new engine and extends the KerasSerializer class.

Eg.

`class Trainer(KerasSerializer, EngineBaseTraining):
  ...
`
`class PredictionPreparator(KerasSerializer, EngineBasePrediction):
  ...
`
and 

`class Predictor(KerasSerializer, EngineBasePrediction):
  ...
`
