### PR TITLE
allow-root added for notebook

### DIFF
--- a/marvin_python_toolbox/management/notebook.py
+++ b/marvin_python_toolbox/management/notebook.py
@@ -50,7 +50,7 @@ def notebook(ctx, port, enable_security, spark_conf, allow_root):
     ]
 
     command.append("--NotebookApp.token=") if not enable_security else None
-    command.append("--allow-root") if not allow_root else None
+    command.append("--allow-root") if allow_root else None
 
     ret = os.system(' '.join(command))
     sys.exit(ret)

--- a/marvin_python_toolbox/management/notebook.py
+++ b/marvin_python_toolbox/management/notebook.py
@@ -31,12 +31,13 @@ def cli():
 @click.option('--port', '-p', default=8888, help='Jupyter server port')
 @click.option('--enable-security', is_flag=True, help='Enable jupyter notebook token security.')
 @click.option('--spark-conf', '-c', envvar='SPARK_CONF_DIR', type=click.Path(exists=True), help='Spark configuration folder path to be used in this session')
+@click.option('--allow-root', is_flag=True, help='Run notebook from root user.')
 @click.pass_context
-def notebook_cli(ctx, port, enable_security, spark_conf):
-    notebook(ctx, port, enable_security, spark_conf)
+def notebook_cli(ctx, port, enable_security, spark_conf, allow_root):
+    notebook(ctx, port, enable_security, spark_conf, allow_root)
 
 
-def notebook(ctx, port, enable_security, spark_conf):
+def notebook(ctx, port, enable_security, spark_conf, allow_root):
     notebookdir = os.path.join(ctx.obj['base_path'], 'notebooks')
     command = [
         "SPARK_CONF_DIR={0} YARN_CONF_DIR={0}".format(spark_conf if spark_conf else os.path.join(os.environ["SPARK_HOME"], "conf")),
@@ -49,6 +50,7 @@ def notebook(ctx, port, enable_security, spark_conf):
     ]
 
     command.append("--NotebookApp.token=") if not enable_security else None
+    command.append("--allow-root") if not allow_root else None
 
     ret = os.system(' '.join(command))
     sys.exit(ret)

--- a/tests/management/test_notebook.py
+++ b/tests/management/test_notebook.py
@@ -36,10 +36,11 @@ def test_notebook(system_mocked, sys_mocked):
     ctx = mocked_ctx()
     port = 8888
     enable_security = False
+    allow_root = False
     spark_conf = '/opt/spark/conf'
     system_mocked.return_value = 1
 
-    notebook(ctx, port, enable_security, spark_conf)
+    notebook(ctx, port, enable_security, spark_conf, allow_root)
 
     system_mocked.assert_called_once_with('SPARK_CONF_DIR=/opt/spark/conf YARN_CONF_DIR=/opt/spark/conf jupyter notebook --notebook-dir /tmp/notebooks --ip 0.0.0.0 --port 8888 --no-browser --config ' + os.environ["MARVIN_ENGINE_PATH"] + '/marvin_python_toolbox/extras/notebook_extensions/jupyter_notebook_config.py --NotebookApp.token=')
 
@@ -50,10 +51,11 @@ def test_notebook_with_security(system_mocked, sys_mocked):
     ctx = mocked_ctx()
     port = 8888
     enable_security = True
+    allow_root = False
     spark_conf = '/opt/spark/conf'
     system_mocked.return_value = 1
 
-    notebook(ctx, port, enable_security, spark_conf)
+    notebook(ctx, port, enable_security, spark_conf, allow_root)
 
     system_mocked.assert_called_once_with('SPARK_CONF_DIR=/opt/spark/conf YARN_CONF_DIR=/opt/spark/conf jupyter notebook --notebook-dir /tmp/notebooks --ip 0.0.0.0 --port 8888 --no-browser --config ' + os.environ["MARVIN_ENGINE_PATH"] + '/marvin_python_toolbox/extras/notebook_extensions/jupyter_notebook_config.py')
 


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Run notebook from root user


How to test new changes:
- Run "marvin notebook --allow-root" as root user


@marvin-ai/marvin-core-team
